### PR TITLE
add ```with-graph``` macro

### DIFF
--- a/src/Hermes/core.clj
+++ b/src/Hermes/core.clj
@@ -25,6 +25,11 @@
                                        (if (string? m)
                                          (TitanFactory/open m)
                                          (TitanFactory/open (convert-config-map m)))))))
+(defmacro with-graph
+  [g & forms]
+  `(binding [*graph* ~g]
+     ~@forms))
+
 (defmacro transact! [& forms]
   `(try
      (let [tx#      (.startTransaction *graph*)


### PR DESCRIPTION
Useful when the graph is opened in a different thread.

Allows you to write code like this:

```
(with-graph g
  ;; do stuff with *graph* bound to g
)
```
