### PR TITLE
Fix indexes in the vertex test.

### DIFF
--- a/src/hermes/core.clj
+++ b/src/hermes/core.clj
@@ -1,9 +1,7 @@
 (ns hermes.core
   (:import (com.thinkaurelius.titan.core TitanFactory)
            (com.tinkerpop.blueprints Element TransactionalGraph TransactionalGraph$Conclusion)
-           (org.apache.commons.configuration BaseConfiguration))
-  (:use hermes.reflect))
-
+           (org.apache.commons.configuration BaseConfiguration)))
 
 (def ^{:dynamic true} *graph*)
 

--- a/test/hermes/vertex_test.clj
+++ b/test/hermes/vertex_test.clj
@@ -47,8 +47,7 @@
 
 (deftest test-find-by-kv
   (g/open)
-  (println "TODO: Do in memory graphs have indexes?")
-  (t/create-vertex-key :age Long)
+  (t/create-vertex-key :age Long {:indexed true})
   (let [v1 (v/create! {:age  1
                       :name "A"})
         v2 (v/create! {:age 2


### PR DESCRIPTION
In-memory graphs can have indexes.  I defined :age to be an indexed key and the tests stopped warning about non-indexed keys.
