### PR TITLE
Failing test with clean hbase

### DIFF
--- a/test/hermes/persistent/vertex_test.clj
+++ b/test/hermes/persistent/vertex_test.clj
@@ -26,24 +26,25 @@
   (g/open conf)
   (g/transact! (t/create-vertex-key-once :first-name String {:indexed true})
                (t/create-vertex-key-once :last-name  String {:indexed true}))  
-  (let [v1-a (v/upsert! :first-name
-                        {:first-name "Zack"
-                         :last-name "Maril"
-                         :test 0})
-        v1-b (v/upsert! :first-name
-                        {:first-name "Zack"
-                         :last-name "Maril"
-                         :test 1})
-        v2   (v/upsert! :first-name
-                        {:first-name "Brooke"
-                         :last-name "Maril"})]
-    (is (= 1
-           (v/get-property (v/refresh (first v1-a)) :test)
-           (v/get-property (v/refresh (first v1-b)) :test)))
+  (g/transact!
+    (let [v1-a (v/upsert! :first-name
+                          {:first-name "Zack"
+                           :last-name "Maril"
+                           :test 0})
+          v1-b (v/upsert! :first-name
+                          {:first-name "Zack"
+                           :last-name "Maril"
+                           :test 1})
+          v2   (v/upsert! :first-name
+                          {:first-name "Brooke"
+                           :last-name "Maril"})]
+      (is (= 1
+             (v/get-property (v/refresh (first v1-a)) :test)
+             (v/get-property (v/refresh (first v1-b)) :test)))
 
-    (v/upsert! :last-name {:last-name "Maril"
-                           :heritage "Some German Folks"})
-    (is (= "Some German Folks"
-           (v/get-property (v/refresh (first v1-a)) :heritage)
-           (v/get-property (v/refresh (first v1-b)) :heritage)
-           (v/get-property (v/refresh (first v2)) :heritage)))))
+      (v/upsert! :last-name {:last-name "Maril"
+                             :heritage "Some German Folks"})
+      (is (= "Some German Folks"
+             (v/get-property (v/refresh (first v1-a)) :heritage)
+             (v/get-property (v/refresh (first v1-b)) :heritage)
+             (v/get-property (v/refresh (first v2)) :heritage))))))

--- a/test/hermes/persistent/vertex_test.clj
+++ b/test/hermes/persistent/vertex_test.clj
@@ -11,16 +11,16 @@
   (g/open conf)
   (g/transact! (t/create-vertex-key-once :age Long {:indexed true}))
   (g/transact!
-   (let [v1 (v/create! {:age  1
-                        :name "A"})
-         v2 (v/create! {:age 2
-                        :name "B"})
-         v3 (v/create! {:age 2
-                        :name "C"})]
-     (is (= #{"A"}
-            (set (map #(v/get-property % :name) (v/find-by-kv :age 1)))))
-     (is (= #{"B" "C"}
-            (set (map #(v/get-property % :name) (v/find-by-kv :age 2))))))))
+    (let [v1 (v/create! {:age  1
+                         :name "A"})
+          v2 (v/create! {:age 2
+                         :name "B"})
+          v3 (v/create! {:age 2
+                         :name "C"})]
+      (is (= #{"A"}
+             (set (map #(v/get-property % :name) (v/find-by-kv :age 1)))))
+      (is (= #{"B" "C"}
+             (set (map #(v/get-property % :name) (v/find-by-kv :age 2))))))))
 
 (deftest test-upsert!-backed-by-hbase
   (g/open conf)
@@ -40,7 +40,7 @@
     (is (= 1
            (v/get-property (v/refresh (first v1-a)) :test)
            (v/get-property (v/refresh (first v1-b)) :test)))
-    
+
     (v/upsert! :last-name {:last-name "Maril"
                            :heritage "Some German Folks"})
     (is (= "Some German Folks"


### PR DESCRIPTION
This patch has an indentation fix in `test-find-by-kv-backed-by-hbase`.

More importantly, it fixes `test-upsert!-backed-by-hbase`, which was failing on a clean hbase because the `upsert`s were not inside a `transact`.
