### PR TITLE
Don't refresh arguments to upsert! and upconnect!

### DIFF
--- a/src/hermes/edge.clj
+++ b/src/hermes/edge.clj
@@ -56,10 +56,8 @@
    edge is created with the given data."
   ([u v label] (upconnect! u v label {}))
   ([u v label data]
-      (let [fresh-u (v/refresh u)
-            fresh-v (v/refresh v)]
-        (if-let [edges (edges-between fresh-u fresh-v label)]
-          (do
-            (doseq [edge edges] (set-properties! edge data))
-            edges)
-          #{(connect! u v label data)}))))
+    (if-let [edges (edges-between u v label)]
+      (do
+        (doseq [edge edges] (set-properties! edge data))
+        edges)
+      #{(connect! u v label data)})))

--- a/src/hermes/vertex.clj
+++ b/src/hermes/vertex.clj
@@ -34,6 +34,6 @@
    (let [vertices (find-by-kv (name k) (k m))]
      (if (empty? vertices)
        (set [(create! m)])
-       (let [r-vertices (map refresh vertices)]
-         (doseq [vertex r-vertices] (set-properties! vertex m))
-         r-vertices))))
+       (do
+         (doseq [vertex vertices] (set-properties! vertex m))
+         vertices))))


### PR DESCRIPTION
This patch removes the "refresh" that happens to the arguments to `upsert!`.

This is  slightly opinionated, but I think that users are responsible for managing their own transactions, and the scope of their elemets.  If we stop calling `transact!` for them, we should also stop calling `refresh`.

This patch also removes the "refresh" to the vertices returned by `upconnet!`, which was unecessary because they were just gotten from the graph and are fresh-as-can-be.
