### PR TITLE
retry-transact! with test

### DIFF
--- a/src/hermes/core.clj
+++ b/src/hermes/core.clj
@@ -24,12 +24,6 @@
                                          (TitanFactory/open m)
                                          (TitanFactory/open (convert-config-map m)))))))
 
-(defn- stop-transaction
-  [success?]
-  (let [success-flag TransactionalGraph$Conclusion/SUCCESS
-        failure-flag TransactionalGraph$Conclusion/FAILURE]
-        (.stopTransaction *graph* (if success? success-flag failure-flag))))
-
 (defn- supports-transactions?
   []
   (-> *graph*
@@ -43,10 +37,10 @@
       (let [tx      (.startTransaction *graph*)
             results (binding [*graph* tx] (f))]
         (.commit tx)
-        (stop-transaction true)
+        (.stopTransaction *graph* TransactionalGraph$Conclusion/SUCCESS)
         results)
       (catch Exception e
-        (stop-transaction false)
+        (.stopTransaction *graph* TransactionalGraph$Conclusion/FAILURE)
         (throw e)))
     ; Transactions not supported.
     (f)))

--- a/test/hermes/persistent/core_test.clj
+++ b/test/hermes/persistent/core_test.clj
@@ -1,6 +1,7 @@
 (ns hermes.persistent.core-test
   (:use clojure.test)
   (:require [hermes.core :as g]
+            [hermes.type :as t]
             [hermes.vertex :as v])
   (:use [hermes.persistent.conf :only (conf)])
   (:import  (com.thinkaurelius.titan.graphdb.blueprints TitanInMemoryBlueprintsGraph)
@@ -27,3 +28,30 @@
     (g/open conf)
     (is (thrown? Throwable #"transact!" (v/create!)))))
 
+(deftest test-dueling-transactions
+  (testing "Without retries"
+    (g/open conf)
+    (g/transact!
+      (t/create-vertex-key-once :vertex-id Long {:indexed true
+                                            :unique true}))
+    (let [random-long (long (rand-int 100000))
+          f1 (future (g/transact! (v/upsert! :vertex-id {:vertex-id random-long})))
+          f2 (future (g/transact! (v/upsert! :vertex-id {:vertex-id random-long})))]
+
+      (is (thrown? java.util.concurrent.ExecutionException
+        (do @f1 @f2)))))
+
+  (testing "With retries"
+    (g/open conf)
+    (g/transact!
+      (t/create-vertex-key-once :vertex-id Long {:indexed true
+                                            :unique true}))
+    (let [random-long (long (rand-int 100000))
+          f1 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))
+          f2 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))]
+
+      (do @f1 @f2)
+
+      (is (= 1 (count
+        (g/transact! (v/find-by-kv :vertex-id random-long))))
+        "*graph* has only one vertex with the specified vertex-id"))))

--- a/test/hermes/persistent/core_test.clj
+++ b/test/hermes/persistent/core_test.clj
@@ -33,7 +33,7 @@
     (g/open conf)
     (g/transact!
       (t/create-vertex-key-once :vertex-id Long {:indexed true
-                                            :unique true}))
+                                                 :unique true}))
     (let [random-long (long (rand-int 100000))
           f1 (future (g/transact! (v/upsert! :vertex-id {:vertex-id random-long})))
           f2 (future (g/transact! (v/upsert! :vertex-id {:vertex-id random-long})))]
@@ -45,7 +45,7 @@
     (g/open conf)
     (g/transact!
       (t/create-vertex-key-once :vertex-id Long {:indexed true
-                                            :unique true}))
+                                                 :unique true}))
     (let [random-long (long (rand-int 100000))
           f1 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))
           f2 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))]


### PR DESCRIPTION
I had to factor `transact` into a macro that calls a function.  Similarly, `retry-transact!` is a macro that calls a function.  Only the macros are exposed outside of the namespace.

I'm pretty happy with the tests.  They look just like I wanted, and they pass!

This patch also makes `transact!` a noop if the graph doesn't support transactions.  This is so that we don't try to call `(.stopTransaction FAILURE)` on an in-memory graph, which causes an exception.
