### PR TITLE
Paren bug in retry-transact!

### DIFF
--- a/src/hermes/core.clj
+++ b/src/hermes/core.clj
@@ -57,10 +57,10 @@
      (if (:value res)
        (:value res)
        (if (> try-count max-retries)
-         (throw (:exception res)
+         (throw (:exception res))
          (do
            (Thread/sleep wait-time)
-           (recur max-retries wait-time (inc try-count) f)))))))
+           (recur max-retries wait-time (inc try-count) f))))))
 
 (defmacro retry-transact! [max-retries wait-time & forms]
   "Perform graph operations inside a transaction.  The transaction will retry up to `max-retries` times, and will wait

--- a/test/hermes/persistent/core_test.clj
+++ b/test/hermes/persistent/core_test.clj
@@ -39,7 +39,7 @@
           f2 (future (g/transact! (v/upsert! :vertex-id {:vertex-id random-long})))]
 
       (is (thrown? java.util.concurrent.ExecutionException
-        (do @f1 @f2)))))
+        (do @f1 @f2)) "The futures throw errors.")))
 
   (testing "With retries"
     (g/open conf)
@@ -50,7 +50,11 @@
           f1 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))
           f2 (future (g/retry-transact! 3 100 (v/upsert! :vertex-id {:vertex-id random-long})))]
 
-      (do @f1 @f2)
+      (is (= random-long
+             (g/transact!
+               (v/get-property (v/refresh (first @f1)) :vertex-id))
+             (g/transact!
+               (v/get-property (v/refresh (first @f2)) :vertex-id))) "The futures have the correct values.")
 
       (is (= 1 (count
         (g/transact! (v/find-by-kv :vertex-id random-long))))


### PR DESCRIPTION
Yikes, my bad.

`retry-transact!` wasn't returning any value in the case where no exception is thrown.

Added a failing test and the fix.
