### PR TITLE
Bug: when a transaction returns nil, retry-transact! thinks there was an exception.

### DIFF
--- a/src/hermes/core.clj
+++ b/src/hermes/core.clj
@@ -58,7 +58,7 @@
   (let [res (try {:value (transact!* f)}
               (catch Exception e
                 {:exception e}))]
-     (if (:value res)
+     (if (not (:exception res))
        (:value res)
        (if (> try-count max-retries)
          (throw (:exception res))


### PR DESCRIPTION
Fix was simple.  Test included.
