### PR TITLE
Read/Write graphSON with tests.

### DIFF
--- a/src/hermes/io.clj
+++ b/src/hermes/io.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [hermes.core :as g])
   (:import [com.tinkerpop.blueprints.util.io.graphml GraphMLWriter GraphMLReader]
-           [com.tinkerpop.blueprints.util.io.gml GMLWriter GMLReader]))
+           [com.tinkerpop.blueprints.util.io.gml GMLWriter GMLReader]
+           [com.tinkerpop.blueprints.util.io.graphson GraphSONWriter GraphSONReader]))
 
 (defn- load-graph-with-reader
   [reader string-or-file]
@@ -24,3 +25,15 @@
 (def load-graph-graphml (partial load-graph-with-reader #(GraphMLReader/inputGraph %1 %2)))
 (def write-graph-graphml (partial write-graph-with-writer #(GraphMLWriter/outputGraph %1 %2)))
 
+;; GraphSON
+(def load-graph-graphson (partial load-graph-with-reader #(GraphSONReader/inputGraph %1 %2)))
+
+; write-graph-graphson can take an optional 2nd argument:
+; show-types - determines if types are written explicitly to the JSON
+; Note that for Titan Graphs with types, you will want show-types=true.
+; See https://github.com/tinkerpop/blueprints/wiki/GraphSON-Reader-and-Writer-Library
+(defn write-graph-graphson
+  [string-or-file & [ show-types ]]
+  (write-graph-with-writer
+    #(GraphSONWriter/outputGraph %1 %2 (boolean show-types))
+    string-or-file))

--- a/test/hermes/memory/io_test.clj
+++ b/test/hermes/memory/io_test.clj
@@ -2,6 +2,7 @@
   (:use clojure.test)
   (:require [hermes.core :as g]
             [hermes.io :as io]
+            [hermes.type :as t]
             [hermes.vertex :as v]
             [hermes.edge :as e]
             [clojure.java.io :as clj-io]))
@@ -51,3 +52,75 @@
       (has-n-edges 1)
 
       (delete-graph-file))))
+
+(deftest test-loading-and-saving-graphs-graphson
+  (testing "Without type information"
+    (g/open)
+    (let [filename "my-test-graph.graphson"
+          file (clj-io/file filename)]
+      (letfn [(delete-graph-file [] (clj-io/delete-file file true))] ;; Delete file *silently* (no failure if it don't exist).
+        (delete-graph-file)
+        (let [vertex-1 (v/create!)
+              vertex-2 (v/create!)
+              edge (e/upconnect! vertex-1 vertex-2 "edge")]
+          (io/write-graph-graphson filename))
+
+        ;; Open new graph and read it
+        (g/open)
+        (io/load-graph-graphson filename)
+
+        (has-n-vertices 2)
+        (has-n-edges 1)
+
+        (delete-graph-file))))
+
+  (testing "With a graph with type information"
+    (letfn [(init-graph-with-types []
+              (g/open)
+              (t/create-vertex-key :my-int Integer)
+              (t/create-vertex-key :my-long Long)
+              (t/create-vertex-key :my-float Float)
+              (t/create-vertex-key :my-double Double)
+              (t/create-vertex-key :my-boolean Boolean))]
+      (let [filename-typed "my-test-graph-typed.graphson"
+            filename-untyped "my-test-graph-untyped.graphson"
+            file-typed (clj-io/file filename-typed)
+            file-untyped (clj-io/file filename-untyped)]
+        (letfn [(delete-graph-files []
+                  (clj-io/delete-file file-typed true)
+                  (clj-io/delete-file file-untyped true))] ;; Delete files *silently* (no failure if it don't exist).
+
+          (delete-graph-files)
+          (init-graph-with-types)
+
+          (let [vertex-1 (v/create! {:my-int (int 1)
+                                     :my-long (long 2)
+                                     :my-float (float 3)
+                                     :my-double (double 4)
+                                     :my-boolean true})
+                vertex-2 (v/create! {:my-int (int 10)
+                                     :my-long (long 20)
+                                     :my-float (float 30)
+                                     :my-double (double 40)
+                                     :my-boolean false})
+                edge (e/upconnect! vertex-1 vertex-2 "edge")]
+
+            ; Write one with type info
+            (io/write-graph-graphson filename-typed true)
+
+            ; Write one without type info
+            (io/write-graph-graphson filename-untyped false))
+
+          (testing "Loading a graphson without type infomation"
+            (init-graph-with-types)
+            (is (thrown? java.lang.IllegalArgumentException
+              (io/load-graph-graphson filename-untyped)) "Causes type errors to be thrown"))
+
+          (testing "Loading a graphson with type infomation"
+            (init-graph-with-types)
+            (io/load-graph-graphson filename-typed)
+
+            (has-n-vertices 2)
+            (has-n-edges 1))
+
+          (delete-graph-files))))))


### PR DESCRIPTION
Just realized that gml and graphML formats don't seem to do the right thing with type information.  GraphSON can handle types properly if you tell it to.

This pull requests tests the serialization with and without type information.
